### PR TITLE
Fix IndentationError in lcas/gui.py

### DIFF
--- a/lcas/gui.py
+++ b/lcas/gui.py
@@ -288,150 +288,6 @@ class LCASMainGUI:
 
         ttk.Checkbutton(log_debug_frame, text="Debug Mode",
                         variable=self.debug_mode_var).grid(row=1, column=0, columnspan=2, sticky=tk.W, padx=10, pady=5)
-        feat / ai - integration - fix
-
-        feat / ai - integration - fix
-
-        feat / ai - integration - fix
-
-        feat / ai - integration - fix
-
-        feat / ai - integration - fix
-        main
-        main
-        main
-        main
-
-        ttk.Label(
-            log_debug_frame,
-            text="Plugins Directory:").grid(
-            row=2,
-            column=0,
-            sticky=tk.W,
-            padx=10,
-            pady=5)
-        ttk.Entry(
-            log_debug_frame,
-            textvariable=self.plugins_dir_var,
-            width=50).grid(
-            row=2,
-            column=1,
-            padx=10,
-            pady=5)
-
-        # Analysis Parameters Frame
-        analysis_params_frame = ttk.LabelFrame(
-            scrollable_frame, text="Analysis Parameters")
-        analysis_params_frame.pack(fill=tk.X, padx=20, pady=10)
-
-        ttk.Label(
-            analysis_params_frame,
-            text="Min Probative Score:").grid(
-            row=0,
-            column=0,
-            sticky=tk.W,
-            padx=10,
-            pady=5)
-        ttk.Entry(
-            analysis_params_frame,
-            textvariable=self.min_probative_score_var,
-            width=10).grid(
-            row=0,
-            column=1,
-            padx=10,
-            pady=5)
-
-        ttk.Label(
-            analysis_params_frame,
-            text="Min Relevance Score:").grid(
-            row=1,
-            column=0,
-            sticky=tk.W,
-            padx=10,
-            pady=5)
-        ttk.Entry(
-            analysis_params_frame,
-            textvariable=self.min_relevance_score_var,
-            width=10).grid(
-            row=1,
-            column=1,
-            padx=10,
-            pady=5)
-
-        ttk.Label(
-            analysis_params_frame,
-            text="Similarity Threshold:").grid(
-            row=2,
-            column=0,
-            sticky=tk.W,
-            padx=10,
-            pady=5)
-        ttk.Entry(
-            analysis_params_frame,
-            textvariable=self.similarity_threshold_var,
-            width=10).grid(
-            row=2,
-            column=1,
-            padx=10,
-            pady=5)
-
-        ttk.Label(
-            analysis_params_frame,
-            text="Probative Weight:").grid(
-            row=0,
-            column=2,
-            sticky=tk.W,
-            padx=10,
-            pady=5)
-        ttk.Entry(
-            analysis_params_frame,
-            textvariable=self.probative_weight_var,
-            width=10).grid(
-            row=0,
-            column=3,
-            padx=10,
-            pady=5)
-
-        ttk.Label(
-            analysis_params_frame,
-            text="Relevance Weight:").grid(
-            row=1,
-            column=2,
-            sticky=tk.W,
-            padx=10,
-            pady=5)
-        ttk.Entry(
-            analysis_params_frame,
-            textvariable=self.relevance_weight_var,
-            width=10).grid(
-            row=1,
-            column=3,
-            padx=10,
-            pady=5)
-
-        ttk.Label(
-            analysis_params_frame,
-            text="Admissibility Weight:").grid(
-            row=2,
-            column=2,
-            sticky=tk.W,
-            padx=10,
-            pady=5)
-        ttk.Entry(
-            analysis_params_frame,
-            textvariable=self.admissibility_weight_var,
-            width=10).grid(
-            row=2,
-            column=3,
-            padx=10,
-            pady=5)
-        feat / ai - integration - fix
-
-        feat / ai - integration - fix
-
-        feat / ai - integration - fix
-
-        feat / ai - integration - fix
 
         ttk.Label(
             log_debug_frame,
@@ -557,11 +413,6 @@ class LCASMainGUI:
             padx=10,
             pady=5)
 
-        main
-        main
-        main
-        main
-        main
         # Processing Options Frame
         proc_options_frame = ttk.LabelFrame(
             scrollable_frame, text="Processing Options")
@@ -1014,68 +865,30 @@ class LCASMainGUI:
     def save_configuration(self):
         """Save current configuration"""
         if self.core:
-        feat / ai - integration - fix
-        # Update all config fields from GUI variables, ensuring 12-space
-        # indentation
-
-        # Update all config fields from GUI variables
-        main
-        self.core.config.case_name = self.case_name_var.get()
-        self.core.config.source_directory = self.source_dir_var.get()
-         self.core.config.target_directory = self.target_dir_var.get()
-          self.core.config.plugins_directory = self.plugins_dir_var.get()
-           # self.core.config.enabled_plugins - managed by plugin manager UI /
-           # core logic
-           self.core.config.debug_mode = self.debug_mode_var.get()
+            # Update all config fields from GUI variables
+            self.core.config.case_name = self.case_name_var.get()
+            self.core.config.source_directory = self.source_dir_var.get()
+            self.core.config.target_directory = self.target_dir_var.get()
+            self.core.config.plugins_directory = self.plugins_dir_var.get()
+            # self.core.config.enabled_plugins - managed by plugin manager UI /
+            # core logic
+            self.core.config.debug_mode = self.debug_mode_var.get()
             self.core.config.log_level = self.log_level_var.get()
 
             self.core.config.min_probative_score = self.min_probative_score_var.get()
             self.core.config.min_relevance_score = self.min_relevance_score_var.get()
             self.core.config.similarity_threshold = self.similarity_threshold_var.get()
-        feat / ai - integration - fix
 
-        self.core.config.probative_weight = self.probative_weight_var.get()
-        self.core.config.relevance_weight = self.relevance_weight_var.get()
-         self.core.config.admissibility_weight = self.admissibility_weight_var.get()
+            self.core.config.probative_weight = self.probative_weight_var.get()
+            self.core.config.relevance_weight = self.relevance_weight_var.get()
+            self.core.config.admissibility_weight = self.admissibility_weight_var.get()
 
-        feat / ai - integration - fix
+            self.core.config.enable_deduplication = self.enable_deduplication_var.get()
+            self.core.config.enable_advanced_nlp = self.enable_advanced_nlp_var.get()
+            self.core.config.generate_visualizations = self.generate_visualizations_var.get()
+            self.core.config.max_concurrent_files = self.max_concurrent_files_var.get()
 
-        self.core.config.probative_weight = self.probative_weight_var.get()
-        self.core.config.relevance_weight = self.relevance_weight_var.get()
-         self.core.config.admissibility_weight = self.admissibility_weight_var.get()
-
-        feat / ai - integration - fix
-
-        self.core.config.probative_weight = self.probative_weight_var.get()
-        self.core.config.relevance_weight = self.relevance_weight_var.get()
-         self.core.config.admissibility_weight = self.admissibility_weight_var.get()
-
-        feat / ai - integration - fix
-
-        feat / ai - integration - fix
-        main
-
-        self.core.config.probative_weight = self.probative_weight_var.get()
-        self.core.config.relevance_weight = self.relevance_weight_var.get()
-         self.core.config.admissibility_weight = self.admissibility_weight_var.get()
-
-        feat / ai - integration - fix
-
-        self.core.config.probative_weight = self.probative_weight_var.get()
-        self.core.config.relevance_weight = self.relevance_weight_var.get()
-         self.core.config.admissibility_weight = self.admissibility_weight_var.get()
-
-        main
-        main
-        main
-        main
-        main
-        self.core.config.enable_deduplication = self.enable_deduplication_var.get()
-        self.core.config.enable_advanced_nlp = self.enable_advanced_nlp_var.get()
-         self.core.config.generate_visualizations = self.generate_visualizations_var.get()
-          self.core.config.max_concurrent_files = self.max_concurrent_files_var.get()
-
-           if self.core.save_config():
+            if self.core.save_config():
                 messagebox.showinfo(
                     "Success", "Configuration saved successfully!")
             else:


### PR DESCRIPTION
I resolved an IndentationError in the `save_configuration` method of `lcas/gui.py` caused by unresolved merge conflict markers.

- I removed `feat / ai - integration - fix` and `main` markers.
- I corrected indentation within the `if self.core:` block.
- I removed duplicated lines of code responsible for assigning configuration values for probative_weight, relevance_weight, and admissibility_weight.

The `save_configuration` method should now function as intended, allowing you to save your configuration settings without runtime errors.